### PR TITLE
:bento: [patch] Promote new active and add component queues on team creation

### DIFF
--- a/cmd/samsahai/main.go
+++ b/cmd/samsahai/main.go
@@ -152,12 +152,13 @@ func startCtrlCmd() *cobra.Command {
 				SamsahaiNoProxy:     viper.GetString(s2h.VKS2HNoProxy),
 				ClusterDomain:       viper.GetString(s2h.VKClusterDomain),
 				ActivePromotion: s2h.ActivePromotionConfig{
-					Concurrences:     viper.GetInt(s2h.VKActivePromotionConcurrences),
-					Timeout:          metav1.Duration{Duration: viper.GetDuration(s2h.VKActivePromotionTimeout)},
-					DemotionTimeout:  metav1.Duration{Duration: viper.GetDuration(s2h.VKActivePromotionDemotionTimeout)},
-					RollbackTimeout:  metav1.Duration{Duration: viper.GetDuration(s2h.VKActivePromotionRollbackTimeout)},
-					TearDownDuration: metav1.Duration{Duration: viper.GetDuration(s2h.VKActivePromotionTearDownDuration)},
-					MaxHistories:     viper.GetInt(s2h.VKActivePromotionMaxHistories),
+					Concurrences:          viper.GetInt(s2h.VKActivePromotionConcurrences),
+					Timeout:               metav1.Duration{Duration: viper.GetDuration(s2h.VKActivePromotionTimeout)},
+					DemotionTimeout:       metav1.Duration{Duration: viper.GetDuration(s2h.VKActivePromotionDemotionTimeout)},
+					RollbackTimeout:       metav1.Duration{Duration: viper.GetDuration(s2h.VKActivePromotionRollbackTimeout)},
+					TearDownDuration:      metav1.Duration{Duration: viper.GetDuration(s2h.VKActivePromotionTearDownDuration)},
+					MaxHistories:          viper.GetInt(s2h.VKActivePromotionMaxHistories),
+					PromoteOnTeamCreation: viper.GetBool(s2h.VKActivePromotionOnTeamCreation),
 				},
 				SamsahaiCredential: s2h.SamsahaiCredential{
 					InternalAuthToken: authToken,
@@ -250,6 +251,8 @@ func startCtrlCmd() *cobra.Command {
 		"Previous active environment teardown duration.")
 	cmd.Flags().Int(s2h.VKActivePromotionMaxHistories, 7,
 		"Max stored active promotion histories per team.")
+	cmd.Flags().Bool(s2h.VKActivePromotionOnTeamCreation, true,
+		"Promote active environment when team creation")
 
 	return cmd
 }

--- a/internal/const.go
+++ b/internal/const.go
@@ -48,6 +48,7 @@ const (
 	VKActivePromotionRollbackTimeout  = "active-promotion-rollback-timeout"
 	VKActivePromotionTearDownDuration = "active-promotion-teardown-duration"
 	VKActivePromotionMaxHistories     = "active-promotion-max-histories"
+	VKActivePromotionOnTeamCreation   = "active-promotion-on-team-creation"
 	VKQueueMaxHistoryDays             = "queue-max-history-days"
 )
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -17,8 +17,11 @@ const (
 	ErrImageVersionNotFound      = Error("image version not found")
 	ErrNoDesiredComponentVersion = Error("no desired component version")
 
-	ErrTeamNamespaceStillCreating = Error("still creating namespace")
-	ErrTeamNamespaceStillExists   = Error("destroyed namespace still exists")
+	ErrTeamNamespaceStillCreating     = Error("still creating namespace")
+	ErrTeamNamespaceStillExists       = Error("destroyed namespace still exists")
+	ErrTeamNamespaceEnvObjsCreated    = Error("environment objects is creating")
+	ErrTeamNamespaceComponentNotified = Error("new components is notifying changed")
+	ErrTeamNamespacePromotionCreated  = Error("active promotion is creating")
 
 	ErrActivePromotionTimeout            = Error("active promotion timeout")
 	ErrActiveDemotionTimeout             = Error("demoted active environment timeout")
@@ -69,6 +72,21 @@ func IsNamespaceStillCreating(err error) bool {
 // IsNamespaceStillExists checks namespace still exists
 func IsNamespaceStillExists(err error) bool {
 	return ErrTeamNamespaceStillExists.Error() == err.Error()
+}
+
+// IsNewNamespaceEnvObjsCreated checks ensuring environment objects created
+func IsNewNamespaceEnvObjsCreated(err error) bool {
+	return ErrTeamNamespaceEnvObjsCreated.Error() == err.Error()
+}
+
+// IsNewNamespaceComponentNotified checks ensuring components notified
+func IsNewNamespaceComponentNotified(err error) bool {
+	return ErrTeamNamespaceComponentNotified.Error() == err.Error()
+}
+
+// IsNewNamespacePromotionCreated checks ensuring active promotion created
+func IsNewNamespacePromotionCreated(err error) bool {
+	return ErrTeamNamespacePromotionCreated.Error() == err.Error()
 }
 
 // IsEnsuringPreActiveEnvironmentCreated checks ensuring pre-active created

--- a/internal/samsahai.go
+++ b/internal/samsahai.go
@@ -92,6 +92,9 @@ type ActivePromotionConfig struct {
 
 	// MaxHistories defines max stored histories of active promotion
 	MaxHistories int `json:"maxHistories" yaml:"maxHistories"`
+
+	// OnStagingCreation defines whether promote active environment or not when staging namespace creation?
+	OnStagingCreation bool `json:"onStagingCreation,omitempty" yaml:"onStagingCreation,omitempty"`
 }
 
 // SamsahaiController

--- a/internal/samsahai.go
+++ b/internal/samsahai.go
@@ -93,8 +93,8 @@ type ActivePromotionConfig struct {
 	// MaxHistories defines max stored histories of active promotion
 	MaxHistories int `json:"maxHistories" yaml:"maxHistories"`
 
-	// OnStagingCreation defines whether promote active environment or not when staging namespace creation?
-	OnStagingCreation bool `json:"onStagingCreation,omitempty" yaml:"onStagingCreation,omitempty"`
+	// PromoteOnTeamCreation defines whether auto-promote active environment or not when team creation?
+	PromoteOnTeamCreation bool `json:"promoteOnTeamCreation" yaml:"promoteOnTeamCreation"`
 }
 
 // SamsahaiController

--- a/internal/samsahai/controller.go
+++ b/internal/samsahai/controller.go
@@ -379,8 +379,32 @@ func (c *controller) createNamespace(teamName string, teamNsOpt TeamNamespaceSta
 		return err
 	}
 
+	namespace, nsConditionType := teamNsOpt(teamComp)
 	if err := c.createNamespaceByTeam(teamComp, teamNsOpt); err != nil {
+		if errors.IsNamespaceStillCreating(err) ||
+			errors.IsNewNamespaceEnvObjsCreated(err) ||
+			errors.IsNewNamespaceComponentNotified(err) ||
+			errors.IsNewNamespacePromotionCreated(err) {
+			teamComp.Status.SetCondition(
+				nsConditionType,
+				corev1.ConditionFalse,
+				fmt.Sprintf("%s %s", namespace, err.Error()))
+			if err := c.updateTeamNamespacesStatus(teamComp, teamNsOpt); err != nil {
+				return errors.Wrap(err, "cannot update team conditions while creating namespace")
+			}
+		}
+
 		return err
+	}
+
+	if !teamComp.Status.IsConditionTrue(nsConditionType) {
+		teamComp.Status.SetCondition(
+			nsConditionType,
+			corev1.ConditionTrue,
+			fmt.Sprintf("%s namespace is created and staging ctrl is deployed", namespace))
+		if err := c.updateTeamNamespacesStatus(teamComp, teamNsOpt); err != nil {
+			return errors.Wrap(err, "cannot update team conditions when create namespace success")
+		}
 	}
 
 	return nil
@@ -397,16 +421,6 @@ func (c *controller) createNamespaceByTeam(teamComp *s2hv1beta1.Team, teamNsOpt 
 	ctx := context.TODO()
 	if err := c.client.Get(ctx, types.NamespacedName{Name: namespace}, &namespaceObj); err != nil {
 		if k8serrors.IsNotFound(err) {
-			teamComp.Status.SetCondition(
-				nsConditionType,
-				corev1.ConditionFalse,
-				fmt.Sprintf("%s namespace is creating", namespace))
-
-			logger.Debug("start updating team namespace", "team", teamComp.Name, "namespace", namespace)
-			if err := c.updateTeamNamespacesStatus(teamComp, teamNsOpt); err != nil {
-				return errors.Wrap(err, "cannot update team conditions while creating namespace")
-			}
-
 			logger.Debug("start creating namespace", "team", teamComp.Name, "namespace", namespace)
 			if nsConditionType == s2hv1beta1.TeamNamespaceStagingCreated {
 				if err := controllerutil.SetControllerReference(teamComp, &namespaceObj, c.scheme); err != nil {
@@ -427,12 +441,15 @@ func (c *controller) createNamespaceByTeam(teamComp *s2hv1beta1.Team, teamNsOpt 
 	logger.Debug("start creating s2h environment objects",
 		"team", teamComp.Name, "namespace", namespace)
 	if err := c.createEnvironmentObjects(teamComp, namespace); err != nil {
-		return err
+		logger.Error(err, "cannot create environment objects",
+			"team", teamComp.Name, "namespace", namespace)
+		return errors.ErrTeamNamespaceEnvObjsCreated
 	}
 
 	if !teamComp.Status.IsConditionTrue(nsConditionType) {
 		if c.configs.PostNamespaceCreation != nil {
-			logger.Debug("start executing command after creating namespace", "namespace", namespace)
+			logger.Debug("start executing command after creating namespace",
+				"team", teamComp.Name, "namespace", namespace)
 			if err := c.runPostNamespaceCreation(namespace, teamComp); err != nil {
 				logger.Error(err, "cannot execute command after creating namespace",
 					"namespace", namespace)
@@ -440,29 +457,22 @@ func (c *controller) createNamespaceByTeam(teamComp *s2hv1beta1.Team, teamNsOpt 
 		}
 
 		if nsConditionType == s2hv1beta1.TeamNamespaceStagingCreated {
-			logger.Debug("start notifying changed components",
-				"team", teamComp.Name, "namespace", namespace)
+			logger.Debug("start notifying component", "team", teamComp.Name, "namespace", namespace)
 			if err := c.notifyComponentChanged(teamComp.Name); err != nil {
-				return errors.Wrap(err, "cannot notify component changed while creating staging namespace")
+				logger.Error(err, "cannot notify component changed while creating staging namespace",
+					"team", teamComp.Name, "namespace", namespace)
+				return errors.ErrTeamNamespaceComponentNotified
 			}
 
 			if c.configs.ActivePromotion.PromoteOnTeamCreation {
 				logger.Debug("start creating active promotion",
 					"team", teamComp.Name, "namespace", namespace)
 				if err := c.createActivePromotion(teamComp.Name); err != nil {
-					return errors.Wrap(err, "cannot create active promotion while creating staging namespace")
+					logger.Error(err, "cannot create active promotion while creating staging namespace",
+						"namespace", namespace)
+					return errors.ErrTeamNamespacePromotionCreated
 				}
 			}
-		}
-
-		teamComp.Status.SetCondition(
-			nsConditionType,
-			corev1.ConditionTrue,
-			fmt.Sprintf("%s namespace is created and staging ctrl is deployed", namespace))
-
-		logger.Debug("start updating team namespace", "team", teamComp.Name, "namespace", namespace)
-		if err := c.updateTeamNamespacesStatus(teamComp, teamNsOpt); err != nil {
-			return errors.Wrap(err, "cannot update team conditions when create namespace success")
 		}
 	}
 

--- a/internal/samsahai/controller.go
+++ b/internal/samsahai/controller.go
@@ -443,7 +443,7 @@ func (c *controller) createNamespaceByTeam(teamComp *s2hv1beta1.Team, teamNsOpt 
 	if nsConditionType == s2hv1beta1.TeamNamespaceStagingCreated {
 		teamName := teamComp.Name
 		if err := c.notifyComponentChanged(teamName); err != nil {
-			logger.Error(err, "cannot notify component changed",
+			logger.Error(err, "cannot notify component changed for new staging namespace",
 				"team", teamName, "namespace", namespace)
 		}
 

--- a/internal/samsahai/controller.go
+++ b/internal/samsahai/controller.go
@@ -447,7 +447,7 @@ func (c *controller) createNamespaceByTeam(teamComp *s2hv1beta1.Team, teamNsOpt 
 				"team", teamName, "namespace", namespace)
 		}
 
-		if c.configs.ActivePromotion.OnStagingCreation {
+		if c.configs.ActivePromotion.PromoteOnTeamCreation {
 			if err := c.createActivePromotion(teamName); err != nil {
 				logger.Error(err, "cannot create active promotion for new staging namespace",
 					"team", teamName, "namespace", namespace)

--- a/internal/samsahai/controller.go
+++ b/internal/samsahai/controller.go
@@ -438,19 +438,18 @@ func (c *controller) createNamespaceByTeam(teamComp *s2hv1beta1.Team, teamNsOpt 
 		if err := c.updateTeamNamespacesStatus(teamComp, teamNsOpt); err != nil {
 			return errors.Wrap(err, "cannot update team conditions when create namespace success")
 		}
-	}
 
-	if nsConditionType == s2hv1beta1.TeamNamespaceStagingCreated {
-		teamName := teamComp.Name
-		if err := c.notifyComponentChanged(teamName); err != nil {
-			logger.Error(err, "cannot notify component changed for new staging namespace",
-				"team", teamName, "namespace", namespace)
-		}
+		if nsConditionType == s2hv1beta1.TeamNamespaceStagingCreated {
+			if err := c.notifyComponentChanged(teamComp.Name); err != nil {
+				logger.Error(err, "cannot notify component changed for new staging namespace",
+					"team", teamComp.Name, "namespace", namespace)
+			}
 
-		if c.configs.ActivePromotion.PromoteOnTeamCreation {
-			if err := c.createActivePromotion(teamName); err != nil {
-				logger.Error(err, "cannot create active promotion for new staging namespace",
-					"team", teamName, "namespace", namespace)
+			if c.configs.ActivePromotion.PromoteOnTeamCreation {
+				if err := c.createActivePromotion(teamComp.Name); err != nil {
+					logger.Error(err, "cannot create active promotion for new staging namespace",
+						"team", teamComp.Name, "namespace", namespace)
+				}
 			}
 		}
 	}

--- a/internal/samsahai/internal_process.go
+++ b/internal/samsahai/internal_process.go
@@ -53,7 +53,7 @@ func (c *controller) Start(stop <-chan struct{}) {
 	}
 
 	c.queue.Add(updateHealth{})
-	c.queue.AddAfter(exportMetric{}, (30 * time.Second))
+	c.queue.AddAfter(exportMetric{}, 30*time.Second)
 
 	<-stop
 

--- a/test/e2e/samsahai/ctrl.go
+++ b/test/e2e/samsahai/ctrl.go
@@ -307,7 +307,7 @@ var (
 	}
 )
 
-var _ = FDescribe("Main Controller [e2e]", func() {
+var _ = Describe("Main Controller [e2e]", func() {
 	BeforeEach(func(done Done) {
 		defer close(done)
 
@@ -1472,7 +1472,7 @@ var _ = FDescribe("Main Controller [e2e]", func() {
 	}, 150)
 })
 
-var _ = FDescribe("Main Controller Promote On Team Creation [e2e]", func() {
+var _ = Describe("Main Controller Promote On Team Creation [e2e]", func() {
 	BeforeEach(func(done Done) {
 		defer close(done)
 

--- a/test/e2e/samsahai/ctrl.go
+++ b/test/e2e/samsahai/ctrl.go
@@ -1628,7 +1628,7 @@ var _ = FDescribe("Main Controller Promote On Team Creation [e2e]", func() {
 		wgStop.Wait()
 	}, 60)
 
-	It("should successfully set new active namespace on team", func(done Done) {
+	It("should successfully set new active namespace on new team creation", func(done Done) {
 		defer close(done)
 		ctx := context.TODO()
 
@@ -1772,7 +1772,7 @@ var _ = FDescribe("Main Controller Promote On Team Creation [e2e]", func() {
 		}
 	}, 230)
 
-	It("should not set active namespace on team", func(done Done) {
+	It("should not set active namespace on new team creation", func(done Done) {
 		defer close(done)
 		ctx := context.TODO()
 


### PR DESCRIPTION
<!-- Please fill this template. -->
**What's the change or impact of this PR?**:
- When team is created auto notify changed components to queue and promote new active.

**Related issue link**:
none