### PR TITLE
:bug: [patch] Waiting for helm finished validating & Destroy active namespace when release failed

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -155,3 +155,8 @@ func IsRollingBackActivePromotion(err error) bool {
 func IsEnsuringConfigDestroyed(err error) bool {
 	return ErrEnsureConfigDestroyed.Error() == err.Error()
 }
+
+// IsErrReleaseFailed checks release failed
+func IsErrReleaseFailed(err error) bool {
+	return ErrReleaseFailed.Error() == err.Error()
+}

--- a/internal/samsahai/activepromotion/demote.go
+++ b/internal/samsahai/activepromotion/demote.go
@@ -22,7 +22,26 @@ func (c *controller) demoteActiveEnvironment(ctx context.Context, atpComp *s2hv1
 
 	if prevNs != "" {
 		if err := c.ensureQueueActiveDemoted(teamName, prevNs); err != nil {
-			return err
+			if !s2herrors.IsErrReleaseFailed(err) {
+				return err
+			}
+
+			// destroy active environment if release failed
+			if err := c.destroyActiveEnvironment(ctx, atpComp, atpComp.Status.DestroyedTime); err != nil {
+				if !s2herrors.IsDeletingReleases(err) && !s2herrors.IsEnsuringNamespaceDestroyed(err) {
+					return err
+				}
+			}
+
+			teamName := atpComp.Name
+			prevNs := atpComp.Status.PreviousActiveNamespace
+			logger.Debug("failed to demote active environment, deleted active environment",
+				"team", teamName, "namespace", prevNs)
+			atpComp.Status.SetCondition(s2hv1beta1.ActivePromotionCondActiveDemoted, corev1.ConditionFalse,
+				"Failed to demote active environment, active environment has been deleted")
+			atpComp.SetState(s2hv1beta1.ActivePromotionActiveEnvironment, "Failed to demote active environment")
+
+			return nil
 		}
 	}
 
@@ -41,6 +60,10 @@ func (c *controller) ensureQueueActiveDemoted(teamName, ns string) error {
 	}
 
 	if q.Status.State == s2hv1beta1.Finished {
+		if !q.IsDeploySuccess() {
+			return s2herrors.ErrReleaseFailed
+		}
+
 		return nil
 	}
 
@@ -67,10 +90,9 @@ func (c *controller) checkDemotionTimeout(ctx context.Context, atpComp *s2hv1bet
 		}
 
 		if err := c.destroyActiveEnvironment(ctx, atpComp, atpComp.Status.DestroyedTime); err != nil {
-			if s2herrors.IsDeletingReleases(err) || s2herrors.IsEnsuringNamespaceDestroyed(err) {
-				return s2herrors.ErrEnsureActiveDemoted
+			if !s2herrors.IsDeletingReleases(err) && !s2herrors.IsEnsuringNamespaceDestroyed(err) {
+				return err
 			}
-			return err
 		}
 
 		teamName := atpComp.Name
@@ -90,3 +112,4 @@ func (c *controller) checkDemotionTimeout(ctx context.Context, atpComp *s2hv1bet
 
 	return nil
 }
+

--- a/internal/samsahai/activepromotion/promote.go
+++ b/internal/samsahai/activepromotion/promote.go
@@ -22,6 +22,15 @@ func (c *controller) promoteActiveEnvironment(ctx context.Context, atpComp *s2hv
 	}
 
 	if err := c.ensureQueuePromotedToActive(teamName, targetNs); err != nil {
+		if s2herrors.IsErrReleaseFailed(err) {
+			atpComp.Status.SetResult(s2hv1beta1.ActivePromotionFailure)
+			atpComp.Status.SetCondition(s2hv1beta1.ActivePromotionCondRollbackStarted, corev1.ConditionTrue,
+				"Rollback process has been started due to cannot apply active values file")
+			atpComp.SetState(s2hv1beta1.ActivePromotionRollback,
+				"Active promotion failed due to cannot apply active values file")
+			return nil
+		}
+
 		return err
 	}
 
@@ -60,6 +69,10 @@ func (c *controller) ensureQueuePromotedToActive(teamName, ns string) error {
 	}
 
 	if q.Status.State == s2hv1beta1.Finished {
+		if !q.IsDeploySuccess() {
+			return s2herrors.ErrReleaseFailed
+		}
+
 		return nil
 	}
 

--- a/internal/staging/deploy/helm3/engine.go
+++ b/internal/staging/deploy/helm3/engine.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -113,18 +112,10 @@ func (e *engine) Create(
 		}
 	}
 
-	cliGet := action.NewGetValues(e.actionSettings)
-	v, err := cliGet.Run(refName)
+	// update
+	err = e.helmUpgrade(refName, parentComp.Chart.Name, cpo, values, deployTimeout)
 	if err != nil {
-		return errors.Wrapf(err, "cannot get helm values of release %q", refName)
-	}
-
-	if !reflect.DeepEqual(values, v) {
-		// update
-		err = e.helmUpgrade(refName, parentComp.Chart.Name, cpo, values, deployTimeout)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 
 	return nil

--- a/test/e2e/samsahai/ctrl.go
+++ b/test/e2e/samsahai/ctrl.go
@@ -419,7 +419,7 @@ var _ = Describe("[e2e] Main controller", func() {
 		Expect(err).NotTo(HaveOccurred(), "Delete previous namespace error")
 
 		By("ActivePromotion should be deleted")
-		err = wait.PollImmediate(verifyTime1s, verifyTime10s, func() (ok bool, err error) {
+		err = wait.PollImmediate(verifyTime1s, verifyTime30s, func() (ok bool, err error) {
 			atpTemp := s2hv1beta1.ActivePromotion{}
 			err = client.Get(ctx, types.NamespacedName{Name: atp.Name}, &atpTemp)
 			if err != nil && errors.IsNotFound(err) {
@@ -495,7 +495,7 @@ var _ = Describe("[e2e] Main controller", func() {
 				Expect(data).NotTo(BeNil())
 			}
 		}
-	}, 230)
+	}, 250)
 
 	It("should successfully promote an active environment even demote timeout", func(done Done) {
 		defer close(done)
@@ -1189,7 +1189,7 @@ var _ = Describe("[e2e] Main controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying redis DesiredComponent has been created")
-		err = wait.PollImmediate(verifyTime1s, 50*time.Second, func() (ok bool, err error) {
+		err = wait.PollImmediate(verifyTime1s, verifyTime60s, func() (ok bool, err error) {
 			_, _, _ = utilhttp.Post(server.URL+"/webhook/component", jsonDataRedis)
 			dRedis := s2hv1beta1.DesiredComponent{}
 			if err = client.Get(ctx, types.NamespacedName{Name: redisCompName, Namespace: stgNamespace}, &dRedis); err != nil {
@@ -1295,7 +1295,7 @@ var _ = Describe("[e2e] Main controller", func() {
 			return true, nil
 		})
 		Expect(err).NotTo(HaveOccurred(), "Verify StableComponents error")
-	}, 100)
+	}, 110)
 
 	It("should successfully create outdated component when no any active namespace left but there are active components in team", func(done Done) {
 		defer close(done)
@@ -1947,23 +1947,6 @@ var (
 	stableRedis     = s2hv1beta1.StableComponent{
 		ObjectMeta: metav1.ObjectMeta{Name: redisCompName, Namespace: stgNamespace},
 		Spec:       stableSpecRedis,
-	}
-
-	mockDesiredCompList = &s2hv1beta1.DesiredComponentList{
-		Items: []s2hv1beta1.DesiredComponent{
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: mariaDBCompName, Namespace: stgNamespace},
-				Spec:       s2hv1beta1.DesiredComponentSpec{Name: mariaDBCompName, Repository: "bitnami/mariadb", Version: "10.3.18-debian-9-r32"},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: redisCompName, Namespace: stgNamespace},
-				Spec:       s2hv1beta1.DesiredComponentSpec{Name: redisCompName, Repository: "bitnami/redis", Version: "5.0.7-debian-9-r56"},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: wordpressCompName, Namespace: stgNamespace},
-				Spec:       s2hv1beta1.DesiredComponentSpec{Name: wordpressCompName, Repository: "bitnami/wordpress", Version: "5.2.4-debian-9-r18"},
-			},
-		},
 	}
 
 	mockQueueList = &s2hv1beta1.QueueList{


### PR DESCRIPTION
<!-- Please fill this template. -->
**What's the change or impact of this PR?**:
  - Waiting for helm finished doing validation things before revision got increased
  - Combine base and pre-active values before apply
  - Rollback active to 1st revision (base+preactive)
  - Destroy active namespace when failure release detected parallel with promoting active environment

**Related issue link**: