### PR TITLE
:bento: [patch] Update checker error message for reporter

### DIFF
--- a/internal/config/controller.go
+++ b/internal/config/controller.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -584,11 +582,11 @@ func (c *controller) ensureConfigChanged(teamName, namespace string) error {
 }
 
 func (c *controller) EnsureConfigTemplateChanged(config *s2hv1beta1.Config) error {
-	template := config.Spec.Template
-	if template != "" && template != config.Name {
-		templateObj, err := c.getConfig(template)
+	configTemplate := config.Spec.Template
+	if configTemplate != "" && configTemplate != config.Name {
+		templateObj, err := c.getConfig(configTemplate)
 		if err != nil {
-			logger.Error(err, "config template not found", "template", template)
+			logger.Error(err, "config template not found", "template", configTemplate)
 			return err
 		}
 
@@ -598,11 +596,9 @@ func (c *controller) EnsureConfigTemplateChanged(config *s2hv1beta1.Config) erro
 
 	} else {
 		config.Status.Used = config.Spec
-
 	}
-	bytesConfigComp, _ := json.Marshal(&config.Status.Used)
-	bytesHashID := md5.Sum(bytesConfigComp)
-	hashID := fmt.Sprintf("%x", bytesHashID)
+
+	hashID := internal.GenConfigHashID(config.Status)
 
 	if !config.Status.SyncTemplate {
 		config.Status.SyncTemplate = true

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -17,6 +17,7 @@ const (
 	ErrRequestTimeout            = Error("request timeout")
 	ErrExecutionTimeout          = Error("execution timeout")
 	ErrImageVersionNotFound      = Error("image version not found")
+	ErrInternalCheckerError      = Error("internal checker error")
 	ErrNoDesiredComponentVersion = Error("no desired component version")
 
 	ErrTeamNamespaceStillCreating     = Error("still creating namespace")
@@ -66,8 +67,15 @@ type Error string
 // Error overrides error
 func (e Error) Error() string { return string(e) }
 
+// IsImageNotFound checks image not found error
 func IsImageNotFound(err error) bool {
 	return ErrImageVersionNotFound.Error() == err.Error()
+}
+
+// IsInternalCheckerError checks internal checker error
+func IsInternalCheckerError(err error) bool {
+	return ErrInternalCheckerError.Error() == err.Error() ||
+		strings.Contains(err.Error(), ErrInternalCheckerError.Error())
 }
 
 // IsNamespaceStillCreating checks namespace is still creating

--- a/internal/reporter.go
+++ b/internal/reporter.go
@@ -150,19 +150,24 @@ func NewActivePromotionReporter(status s2hv1beta1.ActivePromotionStatus, s2hConf
 type ImageMissingReporter struct {
 	TeamName      string `json:"teamName,omitempty"`
 	ComponentName string `json:"componentName,omitempty"`
+	// Reason represents error reason
+	Reason        string `json:"reason,omitempty"`
 	Envs          map[string]string
 	s2hv1beta1.Image
 	SamsahaiConfig
 }
 
 // NewImageMissingReporter creates image missing reporter object
-func NewImageMissingReporter(image s2hv1beta1.Image, s2hConfig SamsahaiConfig, teamName, compName string) *ImageMissingReporter {
+func NewImageMissingReporter(image s2hv1beta1.Image, s2hConfig SamsahaiConfig,
+	teamName, compName, reason string) *ImageMissingReporter {
+
 	c := &ImageMissingReporter{
 		SamsahaiConfig: s2hConfig,
 		TeamName:       teamName,
 		ComponentName:  compName,
 		Image:          image,
 		Envs:           listEnv(),
+		Reason:         reason,
 	}
 
 	return c

--- a/internal/reporter/msteams/reporter_test.go
+++ b/internal/reporter/msteams/reporter_test.go
@@ -491,7 +491,8 @@ var _ = Describe("send ms teams message", func() {
 				"pass", s2hmsteams.WithMSTeamsClient(mockMSTeamsCli))
 
 			img := s2hv1beta1.Image{Repository: "registry/comp-1", Tag: "1.0.0"}
-			imageMissingRpt := internal.NewImageMissingReporter(img, internal.SamsahaiConfig{}, "owner", "comp1")
+			imageMissingRpt := internal.NewImageMissingReporter(img, internal.SamsahaiConfig{},
+				"owner", "comp1", "internal server error")
 			err := r.SendImageMissing(configCtrl, imageMissingRpt)
 			g.Expect(mockMSTeamsCli.accessTokenCalls).Should(Equal(1))
 			g.Expect(mockMSTeamsCli.getGroupIDCalls).Should(Equal(2))
@@ -499,6 +500,7 @@ var _ = Describe("send ms teams message", func() {
 			g.Expect(mockMSTeamsCli.postMessageCalls).Should(Equal(3))
 			g.Expect(mockMSTeamsCli.channels).Should(Equal([]string{"chan1-1", "chan1-2", "chan2-1"}))
 			g.Expect(mockMSTeamsCli.message).Should(ContainSubstring("registry/comp-1:1.0.0"))
+			g.Expect(mockMSTeamsCli.message).Should(ContainSubstring("internal server error"))
 			g.Expect(err).Should(BeNil())
 		})
 	})

--- a/internal/reporter/rest/reporter_test.go
+++ b/internal/reporter/rest/reporter_test.go
@@ -239,7 +239,8 @@ var _ = Describe("send rest message", func() {
 			g.Expect(configCtrl).ShouldNot(BeNil())
 
 			client := rest.New(rest.WithRestClient(rest.NewRest(server.URL)))
-			imageMissingRpt := internal.NewImageMissingReporter(img, internal.SamsahaiConfig{}, "owner", "comp1")
+			imageMissingRpt := internal.NewImageMissingReporter(img, internal.SamsahaiConfig{},
+				"owner", "comp1", "")
 			err := client.SendImageMissing(configCtrl, imageMissingRpt)
 			g.Expect(err).To(BeNil(), "request should not thrown any error")
 		})

--- a/internal/reporter/shell/reporter_test.go
+++ b/internal/reporter/shell/reporter_test.go
@@ -100,7 +100,8 @@ var _ = Describe("shell command reporter", func() {
 			configCtrl := newMockConfigCtrl("")
 
 			img := s2hv1beta1.Image{Repository: "docker.io/hello-a", Tag: "2018.01.01"}
-			imageMissingRpt := internal.NewImageMissingReporter(img, internal.SamsahaiConfig{}, "owner", "comp1")
+			imageMissingRpt := internal.NewImageMissingReporter(img, internal.SamsahaiConfig{},
+				"owner", "comp1", "")
 			err := r.SendImageMissing(configCtrl, imageMissingRpt)
 			g.Expect(err).NotTo(HaveOccurred())
 

--- a/internal/reporter/slack/reporter_test.go
+++ b/internal/reporter/slack/reporter_test.go
@@ -456,11 +456,13 @@ var _ = Describe("send slack message", func() {
 			mockSlackCli := &mockSlack{}
 			r := s2hslack.New("mock-token", s2hslack.WithSlackClient(mockSlackCli))
 			img := s2hv1beta1.Image{Repository: "registry/comp-1", Tag: "1.0.0"}
-			imageMissingRpt := internal.NewImageMissingReporter(img, internal.SamsahaiConfig{}, "owner", "comp1")
+			imageMissingRpt := internal.NewImageMissingReporter(img, internal.SamsahaiConfig{},
+				"owner", "comp1", "internal checker error")
 			err := r.SendImageMissing(configCtrl, imageMissingRpt)
 			g.Expect(mockSlackCli.postMessageCalls).Should(Equal(2))
 			g.Expect(mockSlackCli.channels).Should(Equal([]string{"chan1", "chan2"}))
 			g.Expect(mockSlackCli.message).Should(ContainSubstring("registry/comp-1:1.0.0"))
+			g.Expect(mockSlackCli.message).Should(ContainSubstring("internal checker error"))
 			g.Expect(err).Should(BeNil())
 		})
 	})

--- a/internal/samsahai.go
+++ b/internal/samsahai.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"crypto/md5"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -290,4 +292,24 @@ func GenPullRequestComponentName(component, prNumber string) string {
 type PullRequestData struct {
 	// PRNumber defines a pull request number
 	PRNumber string
+}
+
+// GenConfigHashID generates config hash from Config status.used
+func GenConfigHashID(configStatus s2hv1beta1.ConfigStatus) string {
+	configUsed := configStatus.Used
+	bytesConfigComp, _ := json.Marshal(&configUsed)
+	bytesHashID := md5.Sum(bytesConfigComp)
+	hashID := fmt.Sprintf("%x", bytesHashID)
+
+	return hashID
+}
+
+// GenTeamHashID generates team hash from Team status.used
+func GenTeamHashID(teamStatus s2hv1beta1.TeamStatus) string {
+	teamUsed := teamStatus.Used
+	bytesTeamComp, _ := json.Marshal(teamUsed)
+	bytesHashID := md5.Sum(bytesTeamComp)
+	hashID := fmt.Sprintf("%x", bytesHashID)
+
+	return hashID
 }

--- a/internal/samsahai/controller.go
+++ b/internal/samsahai/controller.go
@@ -2,8 +2,6 @@ package samsahai
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -1468,12 +1466,12 @@ func (c *controller) EnsureTeamTemplateChanged(teamComp *s2hv1beta1.Team) error 
 		return err
 	}
 
-	template := configComp.Spec.Template
-	if template != "" && template != teamComp.Name {
+	configTemplate := configComp.Spec.Template
+	if configTemplate != "" && configTemplate != teamComp.Name {
 		templateObj := &s2hv1beta1.Team{}
-		err := c.getTeam(template, templateObj)
+		err := c.getTeam(configTemplate, templateObj)
 		if err != nil {
-			logger.Error(err, "team template not found", "template", template)
+			logger.Error(err, "team template not found", "template", configTemplate)
 			return err
 		}
 
@@ -1485,9 +1483,7 @@ func (c *controller) EnsureTeamTemplateChanged(teamComp *s2hv1beta1.Team) error 
 		teamComp.Status.Used = teamComp.Spec
 	}
 
-	bytesTeamComp, _ := json.Marshal(&teamComp.Status.Used)
-	bytesHashID := md5.Sum(bytesTeamComp)
-	hashID := fmt.Sprintf("%x", bytesHashID)
+	hashID := internal.GenTeamHashID(teamComp.Status)
 
 	if !teamComp.Status.SyncTemplate {
 		teamComp.Status.SyncTemplate = true

--- a/test/e2e/samsahai/ctrl.go
+++ b/test/e2e/samsahai/ctrl.go
@@ -1063,7 +1063,7 @@ var _ = Describe("[e2e] Main controller", func() {
 		})
 
 		By("Delete active environment")
-		_, _, err = utilhttp.Delete(server.URL+"/teams/"+teamName+"/environment/active/delete")
+		_, _, err = utilhttp.Delete(server.URL + "/teams/" + teamName + "/environment/active/delete")
 		Expect(err).NotTo(HaveOccurred(), "Trigger delete active environment error")
 
 		By("Active environment should be deleted")
@@ -2083,7 +2083,6 @@ var (
 	wordpressCompName = "wordpress"
 
 	maxActivePromotionRetry = 2
-	mockTeamTemplateUID     = "eddff85e8b4a4c3a15587a02933a8665"
 
 	mockTeamSpec = s2hv1beta1.TeamSpec{
 		Description: "team for testing",
@@ -2124,7 +2123,7 @@ var (
 					},
 				},
 			},
-			TemplateUID: mockTeamTemplateUID,
+			TemplateUID: internal.GenTeamHashID(s2hv1beta1.TeamStatus{Used: mockTeamSpec}),
 			Used:        mockTeamSpec,
 		},
 	}
@@ -2345,9 +2344,6 @@ var (
 		},
 	}
 
-	configTemplateUID          = "351a6fb96ffd51745ce0d25fdbcec1f0"
-	configOnlyRedisTemplateUID = "82425add0c35197c65f48bcf949ab063"
-
 	mockConfig = s2hv1beta1.Config{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   teamName,
@@ -2355,7 +2351,7 @@ var (
 		},
 		Spec: configSpec,
 		Status: s2hv1beta1.ConfigStatus{
-			TemplateUID: configTemplateUID,
+			TemplateUID: internal.GenConfigHashID(s2hv1beta1.ConfigStatus{Used: configSpec}),
 			Used:        configSpec,
 		},
 	}
@@ -2377,7 +2373,7 @@ var (
 		},
 		Spec: configOnlyRedisSpec,
 		Status: s2hv1beta1.ConfigStatus{
-			TemplateUID: configOnlyRedisTemplateUID,
+			TemplateUID: internal.GenConfigHashID(s2hv1beta1.ConfigStatus{Used: configOnlyRedisSpec}),
 			Used:        configOnlyRedisSpec,
 		},
 	}


### PR DESCRIPTION
<!-- Please fill this template. -->
**What's the change or impact of this PR?**:
- Improve image missing reporter message to be clearer for extra plugins
  - Display error message if only the error type is `InternalCheckerError`
- Fix flaky e2e tests due to config template changed

**Related issue link**: