### PR TITLE
🐛 [patch] ignore pullRequest tearDownDuration if the deployment was not success

### DIFF
--- a/internal/pullrequest/queue/collect_result.go
+++ b/internal/pullrequest/queue/collect_result.go
@@ -106,7 +106,7 @@ func (c *controller) sendPullRequestQueueReport(ctx context.Context, prQueue *s2
 
 func (c *controller) isTearDownDurationCriteriaMet(criteria s2hv1.PullRequestTearDownDurationCriteria,
 	prq *s2hv1.PullRequestQueue) bool {
-	if (prq.Spec.IsPRTriggerFailed != nil && *prq.Spec.IsPRTriggerFailed == true) ||
+	if (prq.Spec.IsPRTriggerFailed != nil && *prq.Spec.IsPRTriggerFailed) ||
 		!prq.Status.IsConditionTrue(s2hv1.PullRequestQueueCondDeployed) {
 		return false
 	}

--- a/internal/pullrequest/queue/collect_result.go
+++ b/internal/pullrequest/queue/collect_result.go
@@ -28,7 +28,7 @@ func (c *controller) collectPullRequestQueueResult(ctx context.Context, prQueue 
 		"Pull request queue result has been collected")
 
 	tearDownDuration := prQueue.Spec.TearDownDuration
-	willUseTearDownDuration := c.isTearDownDurationCriteriaMet(tearDownDuration.Criteria, prQueue.Status.Result)
+	willUseTearDownDuration := c.isTearDownDurationCriteriaMet(tearDownDuration.Criteria, prQueue)
 
 	// set destroyed time only when tearDownDuration is applicable
 	if prQueue.Status.DestroyedTime == nil && willUseTearDownDuration {
@@ -105,14 +105,19 @@ func (c *controller) sendPullRequestQueueReport(ctx context.Context, prQueue *s2
 }
 
 func (c *controller) isTearDownDurationCriteriaMet(criteria s2hv1.PullRequestTearDownDurationCriteria,
-	result s2hv1.PullRequestQueueResult) bool {
+	prq *s2hv1.PullRequestQueue) bool {
+	if (prq.Spec.IsPRTriggerFailed != nil && *prq.Spec.IsPRTriggerFailed == true) ||
+		!prq.Status.IsConditionTrue(s2hv1.PullRequestQueueCondDeployed) {
+		return false
+	}
+
 	switch criteria {
 	case s2hv1.PullRequestTearDownDurationCriteriaBoth:
 		return true
 	case s2hv1.PullRequestTearDownDurationCriteriaFailure:
-		return result == s2hv1.PullRequestQueueFailure
+		return prq.Status.Result == s2hv1.PullRequestQueueFailure
 	case s2hv1.PullRequestTearDownDurationCriteriaSuccess:
-		return result == s2hv1.PullRequestQueueSuccess
+		return prq.Status.Result == s2hv1.PullRequestQueueSuccess
 	}
 	return false
 }

--- a/test/e2e/pullrequest/ctrl.go
+++ b/test/e2e/pullrequest/ctrl.go
@@ -48,7 +48,7 @@ const (
 	verifyTime45s          = 45 * time.Second
 	verifyTime60s          = 60 * time.Second
 	verifyTime75s          = 75 * time.Second
-	verifyTime90s          = 90 * time.Second
+	verifyTime120s         = 120 * time.Second
 	verifyNSCreatedTimeout = verifyTime30s
 )
 
@@ -517,7 +517,7 @@ var _ = Describe("[e2e] Pull request controller", func() {
 		Expect(err).NotTo(HaveOccurred(), "Verify PullRequestTrigger error")
 
 		By("Verifying PullRequestQueue has been created and PullRequestTrigger has been deleted")
-		err = wait.PollImmediate(verifyTime1s, verifyTime90s, func() (ok bool, err error) {
+		err = wait.PollImmediate(verifyTime1s, verifyTime120s, func() (ok bool, err error) {
 			prQueue := s2hv1.PullRequestQueue{}
 			err = client.Get(ctx, types.NamespacedName{Name: singlePRTriggerName, Namespace: stgNamespace}, &prQueue)
 			if err != nil {

--- a/test/e2e/pullrequest/ctrl.go
+++ b/test/e2e/pullrequest/ctrl.go
@@ -515,7 +515,7 @@ var _ = Describe("[e2e] Pull request controller", func() {
 		Expect(err).NotTo(HaveOccurred(), "Verify PullRequestTrigger error")
 
 		By("Verifying PullRequestQueue has been created and PullRequestTrigger has been deleted")
-		err = wait.PollImmediate(verifyTime1s, verifyTime45s, func() (ok bool, err error) {
+		err = wait.PollImmediate(verifyTime1s, verifyTime60s, func() (ok bool, err error) {
 			prQueue := s2hv1.PullRequestQueue{}
 			err = client.Get(ctx, types.NamespacedName{Name: singlePRTriggerName, Namespace: stgNamespace}, &prQueue)
 			if err != nil {
@@ -605,7 +605,7 @@ var _ = Describe("[e2e] Pull request controller", func() {
 		Expect(queue.Spec.Components[1].Repository).To(Equal(prComps[1].Repository))
 		Expect(queue.Spec.Components[1].Version).To(Equal(prComps[1].Version),
 			"dependency version should equal active version")
-	}, 90)
+	}, 110)
 
 	It("should successfully add/remove/run pull request from queue", func(done Done) {
 		defer close(done)

--- a/test/e2e/pullrequest/ctrl.go
+++ b/test/e2e/pullrequest/ctrl.go
@@ -516,7 +516,7 @@ var _ = Describe("[e2e] Pull request controller", func() {
 		Expect(err).NotTo(HaveOccurred(), "Verify PullRequestTrigger error")
 
 		By("Verifying PullRequestQueue has been created and PullRequestTrigger has been deleted")
-		err = wait.PollImmediate(verifyTime1s, verifyTime60s, func() (ok bool, err error) {
+		err = wait.PollImmediate(verifyTime1s, verifyTime75s, func() (ok bool, err error) {
 			prQueue := s2hv1.PullRequestQueue{}
 			err = client.Get(ctx, types.NamespacedName{Name: singlePRTriggerName, Namespace: stgNamespace}, &prQueue)
 			if err != nil {
@@ -606,7 +606,7 @@ var _ = Describe("[e2e] Pull request controller", func() {
 		Expect(queue.Spec.Components[1].Repository).To(Equal(prComps[1].Repository))
 		Expect(queue.Spec.Components[1].Version).To(Equal(prComps[1].Version),
 			"dependency version should equal active version")
-	}, 110)
+	}, 125)
 
 	It("should successfully add/remove/run pull request from queue", func(done Done) {
 		defer close(done)

--- a/test/e2e/pullrequest/ctrl.go
+++ b/test/e2e/pullrequest/ctrl.go
@@ -47,6 +47,7 @@ const (
 	verifyTime30s          = 30 * time.Second
 	verifyTime45s          = 45 * time.Second
 	verifyTime60s          = 60 * time.Second
+	verifyTime75s          = 75 * time.Second
 	verifyNSCreatedTimeout = verifyTime15s
 )
 
@@ -320,7 +321,7 @@ var _ = Describe("[e2e] Pull request controller", func() {
 		Expect(err).NotTo(HaveOccurred(), "Verify PullRequestTrigger error")
 
 		By("Verifying PullRequestQueue has been created and PullRequestTrigger has been deleted")
-		err = wait.PollImmediate(verifyTime1s, verifyTime60s, func() (ok bool, err error) {
+		err = wait.PollImmediate(verifyTime1s, verifyTime75s, func() (ok bool, err error) {
 			prQueue := s2hv1.PullRequestQueue{}
 			err = client.Get(ctx, types.NamespacedName{Name: bundledPRTriggerName, Namespace: stgNamespace}, &prQueue)
 			if err != nil {
@@ -448,7 +449,7 @@ var _ = Describe("[e2e] Pull request controller", func() {
 		Expect(strings.Contains(prQueueHistList.Items[0].Name, bundledPRTriggerName)).To(BeTrue())
 		Expect(prQueueHistList.Items[0].Spec.PullRequestQueue).NotTo(BeNil())
 		Expect(prQueueHistList.Items[0].Spec.PullRequestQueue.Status.Result).To(Equal(s2hv1.PullRequestQueueSuccess))
-	}, 140)
+	}, 150)
 
 	It("should successfully deploy pull request queue with 1 component and dependencies", func(done Done) {
 		defer close(done)

--- a/test/e2e/pullrequest/ctrl.go
+++ b/test/e2e/pullrequest/ctrl.go
@@ -48,7 +48,8 @@ const (
 	verifyTime45s          = 45 * time.Second
 	verifyTime60s          = 60 * time.Second
 	verifyTime75s          = 75 * time.Second
-	verifyNSCreatedTimeout = verifyTime15s
+	verifyTime90s          = 90 * time.Second
+	verifyNSCreatedTimeout = verifyTime30s
 )
 
 var (
@@ -516,7 +517,7 @@ var _ = Describe("[e2e] Pull request controller", func() {
 		Expect(err).NotTo(HaveOccurred(), "Verify PullRequestTrigger error")
 
 		By("Verifying PullRequestQueue has been created and PullRequestTrigger has been deleted")
-		err = wait.PollImmediate(verifyTime1s, verifyTime75s, func() (ok bool, err error) {
+		err = wait.PollImmediate(verifyTime1s, verifyTime90s, func() (ok bool, err error) {
 			prQueue := s2hv1.PullRequestQueue{}
 			err = client.Get(ctx, types.NamespacedName{Name: singlePRTriggerName, Namespace: stgNamespace}, &prQueue)
 			if err != nil {

--- a/test/e2e/samsahai/ctrl.go
+++ b/test/e2e/samsahai/ctrl.go
@@ -49,8 +49,8 @@ const (
 	verifyTime10s          = 10 * time.Second
 	verifyTime15s          = 15 * time.Second
 	verifyTime30s          = 30 * time.Second
-	verifyTime45s          = 45 * time.Second
 	verifyTime60s          = 60 * time.Second
+	verifyTime90s          = 90 * time.Second
 	verifyNSCreatedTimeout = verifyTime15s
 	promoteTimeOut         = 30 * time.Second
 )
@@ -1365,7 +1365,7 @@ var _ = Describe("[e2e] Main controller", func() {
 		Expect(err).NotTo(HaveOccurred(), "Verify redis DesiredComponent error")
 
 		By("Verifying wordpress DesiredComponent has been created")
-		err = wait.PollImmediate(verifyTime1s, verifyTime45s, func() (ok bool, err error) {
+		err = wait.PollImmediate(verifyTime1s, verifyTime90s, func() (ok bool, err error) {
 			_, _, err = utilhttp.Post(server.URL+"/webhook/component", jsonDataWordpress)
 			if err != nil {
 				return false, err


### PR DESCRIPTION
to not set `DestroyedTime` regardless of the `tearDownDuration` if the condition `PullRequestQueueCondDeployed` is not `True` or if `IsPRTriggerFailed` is true.