### PR TITLE
[patch] fix PR trigger - (inferBranch flag not work when has default branch)

### DIFF
--- a/internal/staging/testrunner/gitlab/testrunner.go
+++ b/internal/staging/testrunner/gitlab/testrunner.go
@@ -25,7 +25,7 @@ var logger = s2hlog.Log.WithName(TestRunnerName)
 const (
 	TestRunnerName = "gitlab"
 
-	maxRunnerTimeout      = 15 * time.Second
+	maxRunnerTimeout      = 30 * time.Second
 	maxHTTPRequestTimeout = 10 * time.Second
 
 	baseAPIPath = "api/v4/projects"

--- a/internal/staging/util.go
+++ b/internal/staging/util.go
@@ -82,10 +82,10 @@ func tryInferPullRequestGitlabBranch(confGitlab *s2hv1.ConfigGitlab, MRiid strin
 
 	confGitlabExists := confGitlab != nil
 
-	// infer branch only if branch is not specified
+	// infer branch only if inferBranch flag == True or default branch is not set
 	canInferBranch := confGitlabExists &&
-		confGitlab.GetInferBranch() &&
-		confGitlab.Branch == ""
+		(confGitlab.GetInferBranch() ||
+			confGitlab.Branch == "")
 	canQueryGitlab := confGitlabExists &&
 		confGitlab.ProjectID != "" &&
 		confGitlab.PipelineTriggerToken != ""

--- a/internal/staging/util.go
+++ b/internal/staging/util.go
@@ -66,19 +66,18 @@ func (c *controller) getTestConfiguration(queue *s2hv1.Queue) *s2hv1.ConfigTestR
 
 	// try to infer gitlab MR branch in PR flow
 	if queue.IsPullRequestQueue() && testRunner != nil {
-		gitlabClientGetter := func(token string) gitlab.Gitlab {
-			return gitlab.NewClient(c.gitlabBaseURL, token)
+		gitlabClientGetter := func() gitlab.Gitlab {
+			return gitlab.NewClient(c.gitlabBaseURL, c.gitlabToken)
 		}
 		tryInferPullRequestGitlabBranch(testRunner.Gitlab, queue.Spec.PRNumber, gitlabClientGetter)
 	}
-
 	return testRunner
 }
 
 // tryInferPullRequestGitlabBranch will check whether the Gitlab MR could be fetched from project ID and pipeline token
 // and override branch in testRunner with the associated MR branch.
 func tryInferPullRequestGitlabBranch(confGitlab *s2hv1.ConfigGitlab, MRiid string,
-	gitlabClientGetter func(token string) gitlab.Gitlab) {
+	gitlabClientGetter func() gitlab.Gitlab) {
 
 	confGitlabExists := confGitlab != nil
 
@@ -91,7 +90,7 @@ func tryInferPullRequestGitlabBranch(confGitlab *s2hv1.ConfigGitlab, MRiid strin
 		confGitlab.PipelineTriggerToken != ""
 
 	if canInferBranch && canQueryGitlab && gitlabClientGetter != nil {
-		gl := gitlabClientGetter(confGitlab.PipelineTriggerToken)
+		gl := gitlabClientGetter()
 		if gl != nil {
 			branch, err := gl.GetMRSourceBranch(confGitlab.ProjectID, MRiid)
 			// silently ignore error (in case of error, don't override the branch)

--- a/internal/staging/util_test.go
+++ b/internal/staging/util_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Util", func() {
 			MRiid = "87878"
 		})
 
-		It("interBranch=True defaultBranch=''", func() {
+		It("interBranch=True defaultBranch='', use branch from MR ", func() {
 			gitlabConf.SetInferBranch(true)
 			before := gitlabConf.DeepCopy()
 
@@ -43,7 +43,7 @@ var _ = Describe("Util", func() {
 			g.Expect(gitlabConf.Branch).To(Equal(inferredBranch))
 		})
 
-		It("interBranch=True defaultBranch='test2'", func() {
+		It("interBranch=True defaultBranch='test2', use branch from MR", func() {
 			gitlabConf.SetInferBranch(true)
 			gitlabConf.Branch = "test2"
 			before := gitlabConf.DeepCopy()
@@ -66,7 +66,7 @@ var _ = Describe("Util", func() {
 			g.Expect(gitlabConf.Branch).To(Equal(inferredBranch))
 		})
 
-		It("inferBranch=False defaultBranch=''", func() {
+		It("inferBranch=False defaultBranch='', use branch from MR", func() {
 			gitlabConf.SetInferBranch(false)
 			gitlabConf.Branch = ""
 			before := gitlabConf.DeepCopy()
@@ -89,7 +89,7 @@ var _ = Describe("Util", func() {
 			g.Expect(gitlabConf.Branch).To(Equal(inferredBranch))
 		})
 
-		It("inferBranch=False defaultBranch='test4'", func() {
+		It("inferBranch=False defaultBranch='test4', use default branch", func() {
 			gitlabConf.SetInferBranch(false)
 			gitlabConf.Branch = "test4"
 			before := gitlabConf.DeepCopy()

--- a/internal/staging/util_test.go
+++ b/internal/staging/util_test.go
@@ -23,9 +23,9 @@ var _ = Describe("Util", func() {
 			gitlabClientGetter = nil
 		})
 
-		It("should not infer if false", func() {
-			gitlabConf.SetInferBranch(false)
-			before := gitlabConf.DeepCopy()
+		It("interBranch=True defaultBranch=''", func() {
+			gitlabConf.SetInferBranch(true)
+			//before := gitlabConf.DeepCopy()
 
 			inferredBranch := "falsebranch"
 
@@ -42,11 +42,34 @@ var _ = Describe("Util", func() {
 
 			tryInferPullRequestGitlabBranch(gitlabConf, MRiid, gitlabClientGetter)
 
-			g.Expect(gitlabConf).To(Equal(before))
+			g.Expect(gitlabConf.Branch).To(Equal(inferredBranch))
 		})
 
-		It("should infer if true and branch empty", func() {
+		It("interBranch=True defaultBranch='test2'", func() {
 			gitlabConf.SetInferBranch(true)
+			gitlabConf.Branch = "test2"
+			//before := gitlabConf.DeepCopy()
+
+			inferredBranch := "falsebranch"
+
+			gitlabClientGetter = func(token string) gitlab.Gitlab {
+				g.Expect(token).To(Equal(gitlabConf.PipelineTriggerToken))
+				return mockGitlab{
+					G:                  g,
+					ExpectedRepository: gitlabConf.ProjectID,
+					ExpectedPRNumber:   MRiid,
+					Branch:             inferredBranch,
+					Error:              nil,
+				}
+			}
+
+			tryInferPullRequestGitlabBranch(gitlabConf, MRiid, gitlabClientGetter)
+
+			g.Expect(gitlabConf.Branch).To(Equal(inferredBranch))
+		})
+
+		It("inferBranch=False defaultBranch=''", func() {
+			gitlabConf.SetInferBranch(false)
 			gitlabConf.Branch = ""
 			before := gitlabConf.DeepCopy()
 
@@ -67,17 +90,12 @@ var _ = Describe("Util", func() {
 
 			g.Expect(gitlabConf).ToNot(Equal(before))
 			g.Expect(gitlabConf.Branch).To(Equal(inferredBranch))
-			gitlabConf.Branch = before.Branch
-			// should change only branch field
-			g.Expect(gitlabConf).To(Equal(before))
 		})
 
-		It("should not infer if true and branch not empty", func() {
-			gitlabConf.SetInferBranch(true)
-			gitlabConf.Branch = "abc"
+		It("inferBranch=False defaultBranch='test4'", func() {
+			gitlabConf.SetInferBranch(false)
+			gitlabConf.Branch = "test4"
 			before := gitlabConf.DeepCopy()
-
-			inferredBranch := "truebranch"
 
 			gitlabClientGetter = func(token string) gitlab.Gitlab {
 				g.Expect(token).To(Equal(gitlabConf.PipelineTriggerToken))
@@ -85,7 +103,7 @@ var _ = Describe("Util", func() {
 					G:                  g,
 					ExpectedRepository: before.ProjectID,
 					ExpectedPRNumber:   MRiid,
-					Branch:             inferredBranch,
+					Branch:             "test4",
 					Error:              nil,
 				}
 			}

--- a/internal/staging/util_test.go
+++ b/internal/staging/util_test.go
@@ -29,8 +29,7 @@ var _ = Describe("Util", func() {
 
 			inferredBranch := "falsebranch"
 
-			gitlabClientGetter = func(token string) gitlab.Gitlab {
-				g.Expect(token).To(Equal(gitlabConf.PipelineTriggerToken))
+			gitlabClientGetter := func() gitlab.Gitlab {
 				return mockGitlab{
 					G:                  g,
 					ExpectedRepository: gitlabConf.ProjectID,
@@ -52,8 +51,7 @@ var _ = Describe("Util", func() {
 
 			inferredBranch := "falsebranch"
 
-			gitlabClientGetter = func(token string) gitlab.Gitlab {
-				g.Expect(token).To(Equal(gitlabConf.PipelineTriggerToken))
+			gitlabClientGetter := func() gitlab.Gitlab {
 				return mockGitlab{
 					G:                  g,
 					ExpectedRepository: gitlabConf.ProjectID,
@@ -75,8 +73,7 @@ var _ = Describe("Util", func() {
 
 			inferredBranch := "truebranch"
 
-			gitlabClientGetter = func(token string) gitlab.Gitlab {
-				g.Expect(token).To(Equal(gitlabConf.PipelineTriggerToken))
+			gitlabClientGetter := func() gitlab.Gitlab {
 				return mockGitlab{
 					G:                  g,
 					ExpectedRepository: before.ProjectID,
@@ -97,8 +94,7 @@ var _ = Describe("Util", func() {
 			gitlabConf.Branch = "test4"
 			before := gitlabConf.DeepCopy()
 
-			gitlabClientGetter = func(token string) gitlab.Gitlab {
-				g.Expect(token).To(Equal(gitlabConf.PipelineTriggerToken))
+			gitlabClientGetter := func() gitlab.Gitlab {
 				return mockGitlab{
 					G:                  g,
 					ExpectedRepository: before.ProjectID,

--- a/internal/staging/util_test.go
+++ b/internal/staging/util_test.go
@@ -11,7 +11,6 @@ var _ = Describe("Util", func() {
 	Describe("tryInferPullRequestGitlabBranch", func() {
 		var gitlabConf *s2hv1.ConfigGitlab
 		var MRiid string
-		var gitlabClientGetter func(token string) gitlab.Gitlab
 		g := NewWithT(GinkgoT())
 
 		BeforeEach(func() {
@@ -20,12 +19,11 @@ var _ = Describe("Util", func() {
 				PipelineTriggerToken: "xyz",
 			}
 			MRiid = "87878"
-			gitlabClientGetter = nil
 		})
 
 		It("interBranch=True defaultBranch=''", func() {
 			gitlabConf.SetInferBranch(true)
-			//before := gitlabConf.DeepCopy()
+			before := gitlabConf.DeepCopy()
 
 			inferredBranch := "falsebranch"
 
@@ -41,13 +39,14 @@ var _ = Describe("Util", func() {
 
 			tryInferPullRequestGitlabBranch(gitlabConf, MRiid, gitlabClientGetter)
 
+			g.Expect(gitlabConf).ToNot(Equal(before))
 			g.Expect(gitlabConf.Branch).To(Equal(inferredBranch))
 		})
 
 		It("interBranch=True defaultBranch='test2'", func() {
 			gitlabConf.SetInferBranch(true)
 			gitlabConf.Branch = "test2"
-			//before := gitlabConf.DeepCopy()
+			before := gitlabConf.DeepCopy()
 
 			inferredBranch := "falsebranch"
 
@@ -63,6 +62,7 @@ var _ = Describe("Util", func() {
 
 			tryInferPullRequestGitlabBranch(gitlabConf, MRiid, gitlabClientGetter)
 
+			g.Expect(gitlabConf).ToNot(Equal(before))
 			g.Expect(gitlabConf.Branch).To(Equal(inferredBranch))
 		})
 

--- a/internal/util/gitlab/gitlab.go
+++ b/internal/util/gitlab/gitlab.go
@@ -152,7 +152,7 @@ func (c *Client) GetMRSourceBranch(repository, MRiid string) (string, error) {
 		opts := []http.Option{
 			http.WithTimeout(requestTimeout),
 			http.WithContext(ctx),
-			http.WithHeader("Authorization", gitToken),
+			http.WithHeader("PRIVATE-TOKEN", gitToken),
 		}
 
 		_, res, err := getRequest(getMRSourceBranchAPI, opts...)


### PR DESCRIPTION
<!-- Please fill this template. -->
**What's the change or impact of this PR?**:
* fix: User cannot trigger a pull request using `inferBranch` flag when has default branch set.
* fix: Cannot read MR_IID with the trigger token, switch to Samsahai global service account
* 
**Related issue link**: