### PR TITLE
[patch] fix: supporting special char in cronjob suffix

### DIFF
--- a/internal/config/controller.go
+++ b/internal/config/controller.go
@@ -796,6 +796,8 @@ func (c *controller) detectRemovedStableComponents(comps map[string]*s2hv1.Compo
 func (c *controller) getCronJobSuffix(schedule string) string {
 	suffix := strings.Replace(schedule, " ", "x", -1)
 	suffix = strings.Replace(suffix, "*", "", -1)
+	suffix = strings.Replace(suffix, "/", "", -1)
+	suffix = strings.Replace(suffix, ",", "", -1)
 
 	return suffix
 }

--- a/internal/config/controller.go
+++ b/internal/config/controller.go
@@ -796,8 +796,8 @@ func (c *controller) detectRemovedStableComponents(comps map[string]*s2hv1.Compo
 func (c *controller) getCronJobSuffix(schedule string) string {
 	suffix := strings.Replace(schedule, " ", "x", -1)
 	suffix = strings.Replace(suffix, "*", "", -1)
-	suffix = strings.Replace(suffix, "/", "", -1)
-	suffix = strings.Replace(suffix, ",", "", -1)
+	suffix = strings.Replace(suffix, "/", "e", -1) // e short for every
+	suffix = strings.Replace(suffix, ",", "n", -1) // n short for and
 
 	return suffix
 }

--- a/internal/config/controller_test.go
+++ b/internal/config/controller_test.go
@@ -151,7 +151,7 @@ wordpress:
 		namespaceTest := "namespace"
 		compSource := s2hv1.UpdatingSource("public-registry")
 		redisCompName := "redis"
-		redisSchedules := []string{"0 4 * * *", "0 5 * * *"}
+		redisSchedules := []string{"0 4 * * *", "*/5 2,3 * * *"}
 
 		cronJobCmd := mockController.getCronJobCmd("redis", teamTest, "bitnami/redis")
 		cronJobResources := mockController.getCronJobResources()
@@ -231,10 +231,12 @@ wordpress:
 		It("should create/delete cronjob correctly", func() {
 			g := NewWithT(GinkgoT())
 
-			cronJobName04 := redisConfigComp.Name + "-checker-0x4xxx"
+			cronJobName04 := redisConfigComp.Name + "-checker-" + mockController.getCronJobSuffix(redisSchedules[0])
 			cronJobLabels04 := mockController.getCronJobLabels(cronJobName04, teamTest, redisConfigComp.Name)
-			cronJobName05 := redisConfigComp.Name + "-checker-0x5xxx"
+			cronJobName05 := redisConfigComp.Name + "-checker-" + mockController.getCronJobSuffix(redisSchedules[1])
 			cronJobLabels05 := mockController.getCronJobLabels(cronJobName05, teamTest, redisConfigComp.Name)
+			g.Expect(cronJobName04).To(Equal("redis-checker-0x4xxx"))
+			g.Expect(cronJobName05).To(Equal("redis-checker-e5x2n3xxx"))
 			expectedCronjob := []batchv1beta1.CronJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -275,7 +277,7 @@ wordpress:
 					},
 					Spec: batchv1beta1.CronJobSpec{
 						SuccessfulJobsHistoryLimit: &successfulJobsHistoryLimit,
-						Schedule:                   "0 5 * * *",
+						Schedule:                   "*/5 2,3 * * *",
 						JobTemplate: batchv1beta1.JobTemplateSpec{
 							Spec: batchv1.JobSpec{
 								Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
<!-- Please fill this template. -->
**What's the change or impact of this PR?**:
- support special characters in schedule cronjob that are used in job name

**Related issue detail**:
- when the user set the cronjob schedule with special characters ("/", ",") samsahai can not create k8s job with the suffix with special character
error message:
`2021-01-22T11:55:45.429+0700 ERROR config-ctrl cannot create cronJob {"component": "vsuppciapi-checker-/5xxxx", "error": "CronJob.batch \\"vsuppciapi-checker-/5xxxx\\" is invalid: \[metadata.name: Invalid value: \\"vsuppciapi-checker-/5xxxx\\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '\[a-z0-9\](\[-a-z0-9\]\*\[a-z0-9\])?(\\\\.\[a-z0-9\](\[-a-z0-9\]\*\[a-z0-9\])?)\*')`